### PR TITLE
Refactor: Simplify useTheme hook

### DIFF
--- a/src/helpers/hooks.ts
+++ b/src/helpers/hooks.ts
@@ -1,37 +1,24 @@
 import { Dispatch, RefObject, SetStateAction, useEffect, useLayoutEffect, useState } from 'react';
 import { DEFAULT_FONT_SIZE, DEFAULT_THEME } from './constants';
-import { SetThemeAction, THEMES, ThemeName } from './themes';
+import { THEMES, ThemeName } from './themes';
 import { getContentWidth } from './util';
 
-type ThemeSetter = [ThemeName, SetThemeAction];
+type ThemeSetter = [ThemeName, Dispatch<SetStateAction<ThemeName>>];
 type FontSizeSetter = [number, Dispatch<SetStateAction<number>>];
 
 export function useTheme(): ThemeSetter {
     const localStorageTheme = localStorage.getItem('theme') as ThemeName | null;
     const [currentTheme, setCurrentTheme] = useState(localStorageTheme ?? DEFAULT_THEME);
 
-    function setTheme(theme: ThemeName): void {
-        const root = document.querySelector<HTMLHtmlElement>(':root');
+    useEffect((): void => {
+        localStorage.setItem('theme', currentTheme);
 
-        if (!root) {
-            throw new Error(
-                'There is no <html> element. This would be a very unlikely occurrence.'
-            );
+        for (const [property, value] of Object.entries(THEMES[currentTheme])) {
+            document.documentElement.style.setProperty(property, value);
         }
+    }, [currentTheme]);
 
-        for (const [property, value] of Object.entries(THEMES[theme])) {
-            root.style.setProperty(property, value);
-        }
-
-        if (theme !== currentTheme) {
-            setCurrentTheme(theme);
-            localStorage.setItem('theme', theme);
-        }
-    }
-
-    setTheme(currentTheme);
-
-    return [currentTheme, setTheme];
+    return [currentTheme, setCurrentTheme];
 }
 
 export function useRowCapacity(

--- a/src/helpers/themes.ts
+++ b/src/helpers/themes.ts
@@ -125,4 +125,3 @@ export const THEMES = {
     },
 } satisfies Themes;
 export type ThemeName = keyof typeof THEMES;
-export type SetThemeAction = (theme: ThemeName) => void;


### PR DESCRIPTION
## This PR
- Simplifies the `useTheme` hook with `useEffect`, as the intention is literally a side effect upon changing a state value.
- Does not affect the resultant user-facing behaviour in any meaningful way.